### PR TITLE
fix(media): truncate media playback when to long

### DIFF
--- a/src/components/NowPlaying.svelte
+++ b/src/components/NowPlaying.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { GlazeWmOutput } from "zebar";
 
-  let { glazewm } : { glazewm: GlazeWmOutput }= $props()
+  let { glazewm }: { glazewm: GlazeWmOutput } = $props();
 </script>
 
 {#if glazewm}
@@ -14,7 +14,9 @@
             nothing is playing
           {:else}
             <i class="ti ti-music text-zb-spotify-playing"></i>
-            {child.title}
+            <span class="max-w-md truncate">
+              {child.title}
+            </span>
           {/if}
         {/if}
       {/each}


### PR DESCRIPTION
Quick fix to #17, idealy I'd have some scrolling effect. But that solution seems way to cumbersome atm. So this will do as a quick fix.